### PR TITLE
Bugfixek a TorpedoStore-ban

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -43,7 +43,7 @@ public class TorpedoStore {
 
     if (r >= FAILURE_RATE) {
       // successful firing
-      this.torpedoCount =- numberOfTorpedos;
+      this.torpedoCount -= numberOfTorpedos;
       success = true;
     } else {
       // simulated failure

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -32,7 +32,7 @@ public class TorpedoStore {
 
   public boolean fire(int numberOfTorpedos){
     if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount){
-      new IllegalArgumentException("numberOfTorpedos");
+      throw new IllegalArgumentException("numberOfTorpedos");
     }
 
     boolean success = false;

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -14,6 +14,8 @@ public class TorpedoStore {
 
   private int torpedoCount = 0;
 
+  Random generator = new Random();
+
   public TorpedoStore(int numberOfTorpedos){
     this.torpedoCount = numberOfTorpedos;
 
@@ -36,7 +38,7 @@ public class TorpedoStore {
     boolean success = false;
 
     // simulate random overheating of the launcher bay which prevents firing
-    Random generator = new Random();
+    
     double r = generator.nextDouble();
 
     if (r >= FAILURE_RATE) {


### PR DESCRIPTION
Random generatort az osztályon belül tároljuk, lövés közben most már a lövés számával csökkentjük a maradék torpedó számát